### PR TITLE
Update speed when delayed

### DIFF
--- a/TF2Dodgeball/addons/sourcemod/scripting/TF2Dodgeball.sp
+++ b/TF2Dodgeball/addons/sourcemod/scripting/TF2Dodgeball.sp
@@ -2882,6 +2882,7 @@ void CheckRoundDelays(int iIndex)
 	else
 	{
 		g_fRocketSpeed[iIndex] += g_hCvarDelayPreventionSpeedup.FloatValue;
+		g_fRocketMphSpeed[iIndex] = g_fRocketSpeed[iIndex] * 0.042614;
 	}
 }
 


### PR DESCRIPTION
Currently the speed HUD is not updated when the rocket is delayed and starts speeding up. 

This updates the variable to also update the speed HUD.